### PR TITLE
Migrate to the latest swlegion.

### DIFF
--- a/lib/src/services/catalog.dart
+++ b/lib/src/services/catalog.dart
@@ -5,29 +5,105 @@ import 'package:swlegion/swlegion.dart';
 import 'unique_ids.dart';
 
 class Catalog {
+  static bool _nullOrEqual<T>(T a, T b) {
+    return a == null || a == b;
+  }
+
   /// Catalog that is built-in to this package (not downloaded).
   static final builtIn = Catalog(
     units: aggregate.units,
     upgrades: aggregate.upgrades,
   );
 
-  /// Units in the database.
-  final List<Unit> units;
+  final Map<UnitKey, Unit> _unitsIndexed;
 
-  /// Upgrades in the database.
-  final List<Upgrade> upgrades;
+  static Map<UnitKey, Unit> _indexUnits(Iterable<Unit> units) {
+    final results = <UnitKey, Unit>{};
+    for (final unit in units) {
+      results[unit.toKey()] = unit;
+    }
+    return Map.unmodifiable(results);
+  }
+
+  final Map<UpgradeKey, Upgrade> _upgradesIndexed;
+
+  static Map<UpgradeKey, Upgrade> _indexUpgrades(Iterable<Upgrade> upgrades) {
+    final results = <UpgradeKey, Upgrade>{};
+    for (final upgrade in upgrades) {
+      results[upgrade.toKey()] = upgrade;
+    }
+    return Map.unmodifiable(results);
+  }
 
   Catalog({
     @required Iterable<Unit> units,
     @required Iterable<Upgrade> upgrades,
-  })  : units = List.unmodifiable(units),
-        upgrades = List.unmodifiable(upgrades);
+  })  : _unitsIndexed = _indexUnits(units),
+        _upgradesIndexed = _indexUpgrades(upgrades);
 
-  /// Creates a new empty [ArmyBuilder] with [ArmyBuilder.id] preset.
-  ArmyBuilder createArmy() => ArmyBuilder()
-    ..maxPoints = 800
-    ..id = generateLocalId();
+  /// Units in the database.
+  Iterable<Unit> get units => _unitsIndexed.values;
 
-  /// Creates a new empty [ArmyUnitBuilder] with [ArmyUnitBuilder.id] preset.
-  ArmyUnitBuilder createArmyUnit() => ArmyUnitBuilder()..id = generateLocalId();
+  /// Upgrades in the database.
+  Iterable<Upgrade> get upgrades => _upgradesIndexed.values;
+
+  /// Returns a new empty [ArmyBuilder].
+  ///
+  /// * [ArmyBuilder.id] is assigned a local unique ID.
+  /// * [ArmyBuilder.maxPoints] is preset to [maxPoints] (`800` if omitted).
+  ArmyBuilder createArmy({
+    int maxPoints = 800,
+  }) {
+    return ArmyBuilder()
+      ..maxPoints = maxPoints
+      ..id = generateLocalId();
+  }
+
+  /// Returns a new empty [ArmyUnitBuilder].
+  ///
+  /// * [ArmyUnitBuilder.id] is assigned a local unique ID.
+  ArmyUnitBuilder createArmyUnit() {
+    return ArmyUnitBuilder()..id = generateLocalId();
+  }
+
+  /// Returns the [Unit] for the cooresponding [key].
+  Unit lookupUnit(UnitKey key) => _unitsIndexed[key];
+
+  /// Returns the [Upgrade] for the cooresponding [key].
+  Upgrade lookupUpgrade(UpgradeKey key) => _upgradesIndexed[key];
+
+  /// Returns the sum of all points in the provided [army].
+  int sumArmyPoints(Army army) {
+    return army.units.fold(0, (p, u) => p + sumUnitPoints(u));
+  }
+
+  /// Returns the sum of all points in the provided [armyUnit].
+  int sumUnitPoints(ArmyUnit armyUnit) {
+    final unit = lookupUnit(armyUnit.unit);
+    final upgrades = armyUnit.upgrades.map(lookupUpgrade);
+    return upgrades.fold(unit.points, (p, u) => p + u.points);
+  }
+
+  /// Returns [Unit]s that can be added to an army of [faction].
+  Iterable<Unit> unitsForFaction(Faction faction) {
+    return units.where((f) => f.faction == faction);
+  }
+
+  /// Returns [Upgrade] that can be added to a [slot].
+  ///
+  /// Optionally will further filter by upgrades that are valid for [unit].
+  Iterable<Upgrade> upgradesForSlot(UpgradeSlot slot, {Unit unit}) {
+    return upgrades.where((u) {
+      if (u.type != slot) {
+        return false;
+      }
+      if (unit == null) {
+        return true;
+      }
+      if (!_nullOrEqual(u.restrictedToFaction, unit.faction)) {
+        return false;
+      }
+      return u.restrictedToUnit.isEmpty || u.restrictedToUnit.contains(unit);
+    });
+  }
 }

--- a/lib/src/widgets/tiles/preview_army_tile.dart
+++ b/lib/src/widgets/tiles/preview_army_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hquplink/services.dart';
 import 'package:hquplink/widgets.dart';
 import 'package:swlegion/swlegion.dart';
 
@@ -28,11 +29,12 @@ class PreviewArmyTile extends StatelessWidget {
 
   @override
   build(context) {
+    final catalog = getCatalog(context);
     return Dismissible(
       key: Key(army.id),
       child: ListTile(
         title: Text(army.name),
-        subtitle: Text('${army.points} points'),
+        subtitle: Text('${catalog.sumArmyPoints(army)} points'),
         leading: FactionIcon(
           army.faction,
           height: 24,
@@ -45,7 +47,7 @@ class PreviewArmyTile extends StatelessWidget {
               builder: (context) {
                 return ManageArmyPage(
                   army: army,
-                  onDelete: () => _onDismiss(context),
+                  onDelete: () => _onDismiss(context, catalog),
                   onSave: onUpdate,
                 );
               },
@@ -55,13 +57,17 @@ class PreviewArmyTile extends StatelessWidget {
         },
       ),
       background: const _DismissBackground(),
-      onDismissed: (_) => _onDismiss(context),
+      onDismissed: (_) => _onDismiss(context, catalog),
     );
   }
 
-  void _onDismiss(BuildContext context, {bool confirm = false}) async {
+  void _onDismiss(
+    BuildContext context,
+    Catalog catalog, {
+    bool confirm = false,
+  }) async {
     onDismiss();
-    if (confirm && army.points > 0) {
+    if (confirm && catalog.sumArmyPoints(army) > 0) {
       if (await showConfirmDialog(
         context: context,
         title: 'Delete army?',


### PR DESCRIPTION
Closes https://github.com/hquplink/hquplink/issues/19.

This actually *isn't* a breaking change, since the `Roster` can continue to load a `Unit` or `Upgrade` instance as a `UnitKey` or `UpgradeKey` (the rest of the fields are ignored, and upon saving they will be wiped).